### PR TITLE
ci(workflow): bump actions/checkout to v7

### DIFF
--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Initialize
         uses: github/codeql-action/init@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.10", "3.10.5", "3.10.11", "3.10.14", "3.10.19", "3.11", "3.11.3", "3.11.8", "3.11.11", "3.11.14", "3.12", "3.12.4", "3.12.10", "3.12.11", "3.12.12", "3.13", "3.13.2", "3.13.5", "3.13.8", "3.13.11", "3.14", "3.14.1", "3.14.2"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6


### PR DESCRIPTION
Follow-up to the global actions-bump sweep.

## What changed

- `actions/checkout@v6` → `@v7` (across `.github/workflows/*.yml`)

## Why

The initial scan's regex missed the `- uses: actions/checkout@v6` list-item form. Bumping to v7 keeps the file in line with the rest of the user's stable set. The input surface used here (no `with:` block) is identical across the major.

## Verification

- [x] actionlint clean
- [x] Commit is GPG-signed
- [x] Branched off the default branch (`main`)