### PR TITLE
ci(workflow): pin all external actions to SHA and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["actions/*", "github/*"]
+      third-party:
+        patterns: ["*"]
+        exclude-patterns: ["actions/*", "github/*"]
+    commit-message:
+      prefix: "ci"
+    labels: ["dependencies", "ci"]

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: python
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
 
       - name: Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: ["3.10", "3.10.5", "3.10.11", "3.10.14", "3.10.19", "3.11", "3.11.3", "3.11.8", "3.11.11", "3.11.14", "3.12", "3.12.4", "3.12.10", "3.12.11", "3.12.12", "3.13", "3.13.2", "3.13.5", "3.13.8", "3.13.11", "3.14", "3.14.1", "3.14.2"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Pin all external GitHub Actions in `code-ql.yml` and `python-app.yml` to immutable commit SHAs. Add Dependabot for weekly auto-updates.

Closes #7